### PR TITLE
Convert Bulkcreate to for loop

### DIFF
--- a/.project-cid
+++ b/.project-cid
@@ -1,1 +1,1 @@
-QmPK4Let83xqopeQucaD6Z8mo4cCsZA3aDN7kSUyHaEG8K
+QmYNRtrcD2QKftkff2UpjV3fr3ubPZuYahTNDAct4Ad2NW

--- a/project.yaml
+++ b/project.yaml
@@ -6,6 +6,9 @@ runner:
   node:
     name: '@subql/node-algorand'
     version: '>=1.0.0'
+    options:
+      unfinalizedBlocks: false
+      historical: false
   query:
     name: '@subql/query'
     version: '*'

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -46,7 +46,9 @@ export async function handleBlock(block: AlgorandBlock): Promise<void> {
 
   const txs = block.transactions.map(tx => handleTransaction(tx));
 
-  await store.bulkCreate('Transaction', txs);
+  for (const tx of txs ) {
+    await tx.save()
+  }
 }
 
 


### PR DESCRIPTION
This is to allow POI consistency

Node Runners are also updated, as well as ipfs CID